### PR TITLE
fix(ranking): read provider score from Grafana instead of recomputing it

### DIFF
--- a/src/components/RpcPerformance/ProviderMetricsTable.tsx
+++ b/src/components/RpcPerformance/ProviderMetricsTable.tsx
@@ -2,7 +2,7 @@
 
 import type { CSSProperties, ReactNode } from 'react';
 import Sparkline from '@/components/Chain/Sparkline';
-import { availTier } from './metrics';
+import { groupByRegion, REGION_ORDER, REGION_EMOJI } from './regions';
 import { isNum } from '@/lib/num';
 import type { AvailTier, ScoredProvider } from '@/lib/types';
 
@@ -52,23 +52,6 @@ const TIER_TEXT_CLASS: Record<AvailTier, string> = {
   unhealthy:  'text-tier-unhealthy',
   unknown:    'text-tier-unknown',
 };
-
-const REGION_DISPLAY: Record<string, string> = {
-  fra1: 'DE', sfo1: 'US', sin1: 'SG', hnd1: 'JP',
-  'eu-west-1': 'DE', 'us-east-1': 'US', 'ap-southeast-1': 'SG', 'ap-northeast-1': 'JP',
-};
-const REGION_ORDER: string[] = ['DE', 'US', 'SG', 'JP'];
-const REGION_EMOJI: Record<string, string> = { DE: '🇩🇪', US: '🇺🇸', SG: '🇸🇬', JP: '🇯🇵' };
-
-function groupRegions(regionsRaw: Record<string, number> | undefined): Record<string, number> {
-  const out: Record<string, number> = {};
-  for (const [code, val] of Object.entries(regionsRaw ?? {})) {
-    const label = REGION_DISPLAY[code];
-    if (!label || !isNum(val)) continue;
-    if (out[label] == null || val < out[label]) out[label] = val;
-  }
-  return out;
-}
 
 // Convert a brand "rgb(r,g,b)" string to "rgba(r,g,b,a)"
 const toRgba = (rgb: string, a: number) => rgb.replace('rgb(', 'rgba(').replace(')', `,${a})`);
@@ -140,8 +123,19 @@ export default function ProviderMetricsTable({ providers, accentColor = '#4DAFFF
     ...providers.map((p) => p.p95ms).filter(isNum),
   );
 
-  const regionMaps     = providers.map((p) => groupRegions(p.regions));
+  const regionMaps     = providers.map((p) => groupByRegion(p.regions));
   const presentRegions = REGION_ORDER.filter((r) => regionMaps.some((m) => m[r] != null));
+
+  // Colour each region cell against the best value in ITS OWN region, not
+  // against bestP95ms (a cross-region average). Regional numbers scatter wider
+  // than their average, so the old yardstick pushed cells to yellow/red for no
+  // reason. Seconds here; converted at the call site.
+  const bestByRegion: Record<string, number> = {};
+  for (const m of regionMaps) {
+    for (const [region, val] of Object.entries(m)) {
+      if (bestByRegion[region] == null || val < bestByRegion[region]) bestByRegion[region] = val;
+    }
+  }
 
   // Total region section is always 240px — each column gets an equal share.
   const regionColW = presentRegions.length > 0 ? Math.round(240 / presentRegions.length) : 80;
@@ -175,7 +169,8 @@ export default function ProviderMetricsTable({ providers, accentColor = '#4DAFFF
         <tbody>
           {providers.map((p, i) => {
             const avail   = p.availability;
-            const status  = availTier(avail);
+            // computeScores already derived this from the unrounded success rate.
+            const status  = p.availTier;
             const regions = regionMaps[i];
 
             // Row highlight is brand-derived → CSS variables; hover via class.
@@ -225,8 +220,9 @@ export default function ProviderMetricsTable({ providers, accentColor = '#4DAFFF
                 {/* Regional P95 heatmap */}
                 {presentRegions.map((r) => {
                   const ms = regions[r] != null ? Math.round(regions[r] * 1000) : null;
+                  const bestMs = Math.round((bestByRegion[r] ?? 0) * 1000);
                   return (
-                    <td key={r} className={`px-2 text-center font-mono text-xs tracking-[-0.2px] whitespace-nowrap ${heatCellClass(ms, bestP95ms)}`}>
+                    <td key={r} className={`px-2 text-center font-mono text-xs tracking-[-0.2px] whitespace-nowrap ${heatCellClass(ms, bestMs)}`}>
                       {ms != null ? fmtMs(ms) : <span className="text-fg-ghost">—</span>}
                     </td>
                   );

--- a/src/components/RpcPerformance/metrics.ts
+++ b/src/components/RpcPerformance/metrics.ts
@@ -17,18 +17,25 @@ export function enrichProviders(providers: Provider[]): EnrichedProvider[] {
     p95ms: isNum(p.p95) ? Math.round(p.p95 * 1000) : null,
     p99ms: isNum(p.p99) ? Math.round(p.p99 * 1000) : null,
     p50ms: isNum(p.p50) ? Math.round(p.p50 * 1000) : null,
-    availability: isNum(p.success) ? +(p.success * 100).toFixed(2) : null,
+    // Truncated, not rounded, so the displayed figure can never contradict the
+    // tier colour: rounding 99.897% up to "99.90%" reads as a threshold bug when
+    // availTier (correctly, on the raw value) calls it `acceptable`, not
+    // `healthy`. Truncation only ever moves the number away from the boundary.
+    availability: isNum(p.success) ? Math.floor(p.success * 10000) / 100 : null,
   }));
 }
 
 /**
  * Availability tiers — DISPLAY ONLY (color the availability %, and add a uptime
- * caveat to the summary). They do NOT gate ranking: ordering is purely by
- * grafanaScore, matching the compare dashboard's score panel.
+ * caveat to the summary). They do NOT gate ranking: ordering is purely Grafana's
+ * score, which already folds reliability in.
+ *
+ * Takes a percentage (0–100) and must be given the UNROUNDED value — rounding
+ * first lets 99.895% cross into `healthy`.
  *
  *  healthy     >= 99.9%
- *  acceptable  99.0–99.9%
- *  degraded    95.0–99.0%
+ *  acceptable  [99.0, 99.9)
+ *  degraded    [95.0, 99.0)
  *  unhealthy   < 95.0%
  */
 export function availTier(pct: number | null): AvailTier {
@@ -40,43 +47,34 @@ export function availTier(pct: number | null): AvailTier {
 }
 
 /**
- * Ranking score — matches the compare dashboard's "Provider score" panel:
+ * Attach the ranking score. This app deliberately does NOT compute one: the
+ * formula lives in Grafana's "Provider score" panel and is fetched in
+ * lib/score.ts, so the site and the dashboard it links to can never disagree.
+ * A re-implementation used to live here and did drift out of sync.
  *
- *   score = 1 / mean_over_regions( (1 / p95_region) × successRate_region³ )
- *
- * The speed×reliability term is computed PER REGION, then averaged, then
- * inverted. Lower score = better. SuccessRate³ makes even small reliability
- * drops (99% vs 97%) move the score noticeably. Single-region case reduces to
- * the displayed formula `1 / ((1/rt) × sr³)` = `rt / sr³`.
- *
- * If a provider has no region with both a p95 and a success rate, it is
- * unscoreable and returns Infinity (ranks last). We do NOT substitute a
- * latency-only number — that would silently change the ranking. A wholesale
- * success-query failure surfaces via the partial-data banner instead.
+ * Providers with no score from Grafana get Infinity and rank last, keeping their
+ * incoming p95 order. We do NOT substitute a locally derived number — inventing
+ * a ranking is worse than not having one, and the partial-data banner already
+ * tells the user the score is missing.
  */
-function grafanaScore(p: Provider): number {
-  const terms: number[] = [];
-  for (const [region, p95r] of Object.entries(p.regions)) {
-    const srr = p.regionSuccess[region];
-    if (!isNum(p95r) || p95r <= 0) continue;
-    if (!isNum(srr)) continue; // no reliability data for this region
-    terms.push((1 / p95r) * Math.pow(srr, 3));
-  }
-  if (terms.length === 0) return Infinity;
-  const mean = terms.reduce((a, b) => a + b, 0) / terms.length;
-  return mean > 0 ? 1 / mean : Infinity;
-}
-
 export function computeScores(enriched: EnrichedProvider[]): ScoredProvider[] {
   return enriched.map((p) => ({
     ...p,
-    availTier:    availTier(p.availability),
-    grafanaScore: grafanaScore(p),
+    // Tier off the raw success rate, not the 2dp-rounded display value, so
+    // 99.895% doesn't get rounded up into `healthy`.
+    availTier:    availTier(isNum(p.success) ? p.success * 100 : null),
+    grafanaScore: isNum(p.score) ? p.score : Infinity,
   }));
 }
 
+/**
+ * Ties (notably several unscoreable Infinity providers) keep their incoming
+ * order, which fetchChainData sets to ascending p95 — a sane fallback. Relies on
+ * Array#sort being stable and on an Infinity−Infinity=NaN comparator result
+ * being treated as 0, both of which the spec guarantees.
+ */
 export function sortByScore(providers: ScoredProvider[]): ScoredProvider[] {
-  return [...providers].sort((a, b) => (a.grafanaScore ?? Infinity) - (b.grafanaScore ?? Infinity));
+  return [...providers].sort((a, b) => a.grafanaScore - b.grafanaScore);
 }
 
 export function generateSummary(chain: Chain, sorted: ScoredProvider[]): Summary | null {
@@ -84,9 +82,13 @@ export function generateSummary(chain: Chain, sorted: ScoredProvider[]): Summary
   if (!leader) return null;
   const name = chain.name;
 
-  // The headline always names the actual #1 row (sorted[0]) — no swapping in a
+  // The headline always names the actual top row (sorted[0]) — no swapping in a
   // different provider. Tier only adds a uptime caveat to the detail line.
-  const tier   = leader.availTier ?? availTier(leader.availability);
+  const tier   = leader.availTier;
+  // Without a score from Grafana there is no ranking, and sortByScore has fallen
+  // back to p95 order. Describe what we can actually see instead of claiming a
+  // rank we didn't compute.
+  const ranked = Number.isFinite(leader.grafanaScore);
   const avPct  = isNum(leader.availability) ? `${leader.availability.toFixed(2)}%` : null;
   const p95str = leader.p95ms != null ? `${leader.p95ms} ms P95` : null;
 
@@ -98,7 +100,9 @@ export function generateSummary(chain: Chain, sorted: ScoredProvider[]): Summary
   ].filter(Boolean).join(' · ');
 
   return {
-    headline: `${leader.displayName} ranks #1 for ${name}`,
+    headline: ranked
+      ? `${leader.displayName} ranks #1 for ${name}`
+      : `${leader.displayName} has the lowest P95 for ${name}`,
     detail,
   };
 }

--- a/src/components/RpcPerformance/regions.ts
+++ b/src/components/RpcPerformance/regions.ts
@@ -1,0 +1,37 @@
+// Probe-region identity for the regional P95 columns. Display only — ranking is
+// Grafana's score, which does its own region aggregation.
+//
+// Two probe fleets name the same four regions differently (DigitalOcean-style
+// `fra1`, AWS-style `eu-west-1`), so raw codes are collapsed to one entry per
+// real region. Live data currently only ever uses one fleet's codes, making the
+// aliasing a guard rather than an active correction.
+import { isNum } from '@/lib/num';
+
+const REGION_LABEL: Record<string, string> = {
+  fra1: 'DE', sfo1: 'US', sin1: 'SG', hnd1: 'JP',
+  'eu-west-1': 'DE', 'us-east-1': 'US', 'ap-southeast-1': 'SG', 'ap-northeast-1': 'JP',
+};
+
+export const REGION_ORDER: string[] = ['DE', 'US', 'SG', 'JP'];
+export const REGION_EMOJI: Record<string, string> = { DE: '🇩🇪', US: '🇺🇸', SG: '🇸🇬', JP: '🇯🇵' };
+
+/**
+ * Collapse `region code → value` into `region → value`, taking the MEAN of
+ * codes that resolve to the same region. Mean, not min — picking the better of
+ * two probe locations would flatter whichever providers happen to be probed
+ * twice from one region.
+ *
+ * Unmapped codes pass through under their raw code rather than being dropped, so
+ * a new probe location shows up as missing-from-REGION_ORDER rather than
+ * vanishing into an existing region's average. Callers filter to REGION_ORDER.
+ */
+export function groupByRegion(raw: Record<string, number> | undefined): Record<string, number> {
+  const acc = new Map<string, { sum: number; n: number }>();
+  for (const [code, val] of Object.entries(raw ?? {})) {
+    if (!isNum(val)) continue;
+    const region = REGION_LABEL[code] ?? code;
+    const cur = acc.get(region) ?? { sum: 0, n: 0 };
+    acc.set(region, { sum: cur.sum + val, n: cur.n + 1 });
+  }
+  return Object.fromEntries([...acc].map(([region, { sum, n }]) => [region, sum / n]));
+}

--- a/src/lib/chain-data.ts
+++ b/src/lib/chain-data.ts
@@ -3,6 +3,7 @@ import { cache } from 'react';
 import { runPromQuery, runPromRangeQuery } from './grafana';
 import type { PromInstantResult, PromRangeResult } from './grafana';
 import { providerByRegionQuery, providerTrendQuery, providerSuccessQuery } from './queries';
+import { fetchProviderScores } from './score';
 import type { Chain, ChainData, Provider, TimeRange } from './types';
 
 // Trend (sparkline) span per range. Step is sized to keep ~168 points either way.
@@ -69,7 +70,7 @@ export const fetchChainData = cache(async (chain: Chain, timeRange: TimeRange = 
   const end = minuteAlignedEnd();
   const start = end - windowSeconds;
 
-  const [p50, p95, p99, success, trend] = await Promise.all([
+  const [p50, p95, p99, success, trend, score] = await Promise.all([
     safe('p50', runPromQuery(providerByRegionQuery(chain.promName, 0.5, timeRange))),
     safe('p95', runPromQuery(providerByRegionQuery(chain.promName, 0.95, timeRange))),
     safe('p99', runPromQuery(providerByRegionQuery(chain.promName, 0.99, timeRange))),
@@ -82,18 +83,19 @@ export const fetchChainData = cache(async (chain: Chain, timeRange: TimeRange = 
         step: stepSeconds,
       }),
     ),
+    safe('score', fetchProviderScores(chain.publicToken, timeRange)),
   ]);
 
-  const degradedMetrics = Object.entries({ p50, p95, p99, success, trend })
+  const failedQueries = Object.entries({ p50, p95, p99, success, trend, score })
     .filter(([, r]) => !r.ok)
     .map(([name]) => name);
-  const hadError = degradedMetrics.length > 0;
 
   const p50Map = p50.ok ? quantileByRegionToMap(p50.value) : new Map();
   const p95Map = p95.ok ? quantileByRegionToMap(p95.value) : new Map();
   const p99Map = p99.ok ? quantileByRegionToMap(p99.value) : new Map();
   const trendMap = trend.ok ? trendToMap(trend.value) : new Map<string, number[]>();
   const successMap: RegionMap = success.ok ? quantileByRegionToMap(success.value) : new Map();
+  const scoreMap: Record<string, number> = score.ok ? score.value : {};
 
   const providerNames = new Set<string>([
     ...p50Map.keys(),
@@ -118,9 +120,20 @@ export const fetchChainData = cache(async (chain: Chain, timeRange: TimeRange = 
       regionSuccess: Object.fromEntries(successMap.get(name) ?? []) as Record<string, number>,
       trend: trendMap.get(name) ?? [],
       success: avgOfMap(successMap.get(name)),
+      // Joined on the raw `provider` label, which is the same identity Grafana's
+      // score panel returns.
+      score: Number.isFinite(scoreMap[name]) ? scoreMap[name] : null,
     }))
     .filter((p) => p.p95 !== null)
     .sort((a, b) => (a.p95 as number) - (b.p95 as number));
+
+  // A provider that has latency data but no score would be ranked last without
+  // any explanation, so count that as incomplete data too — e.g. a newly
+  // onboarded provider whose score series hasn't caught up yet.
+  const degradedMetrics = failedQueries.includes('score') || providers.every((p) => p.score !== null)
+    ? failedQueries
+    : [...failedQueries, 'score'];
+  const hadError = degradedMetrics.length > 0;
 
   return {
     chain,

--- a/src/lib/grafana.ts
+++ b/src/lib/grafana.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-const GRAFANA_URL = 'https://chainstack.grafana.net';
+export const GRAFANA_URL = 'https://chainstack.grafana.net';
 const PROM_DS_UID = 'grafanacloud-prom';
 
 /** A single result row from a Prometheus instant query. */

--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -1,0 +1,132 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import { GRAFANA_URL } from './grafana';
+import { isNum } from './num';
+import type { TimeRange } from './types';
+
+/**
+ * Provider score, read from the compare dashboard's "Provider score (lower is
+ * better)" stat panel.
+ *
+ * The scoring formula lives in Grafana and only in Grafana. This app used to
+ * re-implement it in JS, and the two drifted: on Hyperliquid the dashboard puts
+ * Alchemy first while the JS re-implementation put dRPC first. Nothing in this
+ * file computes a score — it fetches one and parses it. Keep it that way; if the
+ * formula needs to change, change the panel.
+ *
+ * Reads the public-dashboard API using the same per-chain tokens as the
+ * "open in Grafana" links, so this path needs no service-account token.
+ */
+
+const RANGE_FROM: Record<TimeRange, string> = { '24h': 'now-24h', '7d': 'now-7d' };
+
+interface DashPanel {
+  id: number;
+  type?: string;
+  panels?: DashPanel[];
+}
+interface PublicDashboard {
+  dashboard?: { panels?: DashPanel[] };
+  panels?: DashPanel[];
+}
+interface QueryFrame {
+  schema: { fields: { name: string; labels?: Record<string, string> }[] };
+  data: { values: (number | null)[][] };
+}
+interface QueryResponse {
+  results?: Record<string, { frames?: QueryFrame[]; error?: string }>;
+}
+
+/**
+ * No `next: { revalidate }` here on purpose: both calls run inside
+ * unstable_cache, which pins nested fetches to `force-no-store` and zeroes any
+ * explicit revalidate. The outer cache is the only caching in this path.
+ */
+async function publicDashFetch<T>(path: string, body?: unknown): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(`${GRAFANA_URL}/api/public/dashboards/${path}`, {
+      method: body ? 'POST' : 'GET',
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`public dashboard ${path} HTTP ${res.status}: ${res.statusText}`);
+    }
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * The score panel carries no title of its own (the heading above it is a
+ * separate text panel) and its id differs per dashboard — 95 on Ethereum, 98 on
+ * Solana, 86 on Base. `stat` is the only stable handle, and every compare
+ * dashboard has exactly one. If that stops holding we throw rather than rank on
+ * a panel we guessed at; the caller degrades to no score.
+ */
+function findScorePanelId(dash: PublicDashboard): number {
+  const flatten = (panels: DashPanel[] | undefined): DashPanel[] =>
+    (panels ?? []).flatMap((p) => [p, ...flatten(p.panels)]);
+
+  const stats = flatten(dash.dashboard?.panels ?? dash.panels).filter((p) => p.type === 'stat');
+  if (stats.length !== 1) {
+    throw new Error(`expected exactly 1 stat panel, found ${stats.length}`);
+  }
+  return stats[0].id;
+}
+
+/**
+ * provider label → score. The panel is an instant query, so each series carries
+ * a single point; `data.values` columns are positionally parallel to
+ * `schema.fields`, so the index of the `Value` field indexes its own column.
+ *
+ * Throws on an empty result: HTTP 200 with no series means the panel answered but
+ * told us nothing, and returning `{}` would rank every provider last in silence
+ * instead of raising the partial-data banner.
+ */
+function parseScores(json: QueryResponse): Record<string, number> {
+  const scores: Record<string, number> = {};
+  for (const result of Object.values(json.results ?? {})) {
+    if (result.error) throw new Error(result.error.slice(0, 200));
+    for (const frame of result.frames ?? []) {
+      const i = frame.schema.fields.findIndex((f) => f.name === 'Value');
+      if (i < 0) continue;
+      const provider = frame.schema.fields[i]?.labels?.provider;
+      if (!provider) continue;
+      const series = frame.data.values[i] ?? [];
+      const latest = series[series.length - 1];
+      if (isNum(latest)) scores[provider] = latest;
+    }
+  }
+  if (Object.keys(scores).length === 0) {
+    throw new Error('score panel returned no provider series');
+  }
+  return scores;
+}
+
+/**
+ * Keyed on (publicToken, range) by unstable_cache. The panel query is a POST, so
+ * Next's fetch cache skips it — the wrapper is what keeps us to one Grafana hit
+ * per chain per 180s (the probes' measurement interval).
+ */
+export const fetchProviderScores = unstable_cache(
+  async (publicToken: string, range: TimeRange): Promise<Record<string, number>> => {
+    const dash = await publicDashFetch<PublicDashboard>(publicToken);
+    const panelId = findScorePanelId(dash);
+    const json = await publicDashFetch<QueryResponse>(
+      `${publicToken}/panels/${panelId}/query`,
+      {
+        intervalMs: 60_000,
+        maxDataPoints: 200,
+        timeRange: { from: RANGE_FROM[range], to: 'now', timezone: 'utc' },
+      },
+    );
+    return parseScores(json);
+  },
+  ['grafana-provider-scores'],
+  { revalidate: 180 },
+);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,11 @@ export interface Provider {
   trend: number[];
   /** mean success rate 0–1 across regions, or null when unknown (display only) */
   success: number | null;
+  /**
+   * Ranking score from Grafana's "Provider score" panel — lower is better.
+   * Null when the panel could not be read; never computed here.
+   */
+  score: number | null;
 }
 
 export interface ChainData {
@@ -31,7 +36,10 @@ export interface ChainData {
   error: boolean;
   /** true when providers exist but some query failed (data incomplete) */
   partial: boolean;
-  /** names of the queries that failed (p50/p95/p99/success/trend) */
+  /**
+   * names of the metrics that came back incomplete
+   * (p50/p95/p99/success/trend/score)
+   */
   degradedMetrics: string[];
 }
 


### PR DESCRIPTION
## What

The provider ranking score is no longer computed in this app. It's fetched from the compare dashboard's **"Provider score (lower is better)"** panel, via the public dashboard API using the per-chain tokens already in `queries.ts`.

The formula now lives in Grafana and only in Grafana. Nothing here derives or adjusts a score.

## Why

`metrics.ts` re-implemented the scoring formula in JS, and it had drifted from the dashboard we link to as the source of truth. Measured against live data: **on Hyperliquid the dashboard ranks Alchemy #1 while this app ranked dRPC #1.** We were publishing a different ranking than the dashboard we cite.

## Heads-up for reviewers

- **This changes published rankings on Hyperliquid** — Alchemy takes #1 from dRPC. Other chains keep their order.
- **New runtime dependencies:** the public dashboards must stay enabled, and each compare dashboard must have exactly one `stat` panel (panel ids genuinely differ per chain — 95 on Ethereum, 98 on Solana, 86 on Base, so discovery is by type). If either assumption breaks, `findScorePanelId` throws, the partial-data banner shows `score unavailable`, and the table falls back to P95 order rather than ranking on a guessed panel.
- No service-account token on this path — it uses the same public tokens as the existing "open in Grafana" links.

## Also fixed

Found while auditing the math, all independent of the score change:

| Fix | Was |
| --- | --- |
| Regional P95 cells coloured against the best value in their own region | Compared against the best *cross-region average*, so cells went yellow/red for no reason |
| Availability tier derived from the raw success rate; display truncates | Tier came off the 2dp-rounded value, so 99.895% was promoted to `healthy` |
| Headline says "has the lowest P95" when no score is available | Claimed "#1" even though the order had silently fallen back to P95 |
| Region-label logic shared in `regions.ts` | Duplicated between table and scoring code with *different* rules — table took `min` of aliased probe codes, score used both |
| A provider with latency data but no score raises the banner | Would have been silently ranked last |

## Verification

- `npx tsc --noEmit` exit 0 · `npm run lint` clean · `npm run build` compiles
- Score fetch exercised against live Grafana for **all 7 chains × both time ranges** — 100% success, 370–920 ms per chain, provider labels match the Prometheus labels we join on
- Dev-server smoke test returns HTTP 200 with `score` absent from the failure log (the five token-authenticated queries fail locally with no `GRAFANA_API_TOKEN`, confirming the public path works independently)
- Reviewed by a second agent against the installed Next 14.0.4 source, which confirmed: frame-index pairing can't mis-pair a provider with another's number; the join is immune to the dashboards' display-rename overrides (`Chainstack`→`Chainstack-Growth`); `unstable_cache` keys on its args and does cache under `force-dynamic`; the `Infinity - Infinity → NaN` comparator and sort stability are spec-guaranteed

**Not verified locally:** rows rendering with real provider data — needs `GRAFANA_API_TOKEN`. Please eyeball the preview deploy.

## Known, deliberately not addressed

Three flaws in Grafana's formula, to be discussed separately and fixed **in the panel**, not here:

1. Region averaging happens in `1/latency` space, so a provider's fastest region dominates and a dead region barely registers.
2. The aggregate P95 is an unweighted mean over 7–8 `api_method` values. On live Ethereum, `eth_subscribe` alone is ~60% of Alchemy's score and `eth_subscribe` + `eth_getLogs` are ~86% of dRPC's.
3. Rank gaps are often inside the noise — Arbitrum's 24h #1→#2 gap was 0.3%, and its 7d #1 is a different provider than its 24h #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider performance scores to RPC monitoring.
  * Added regional aggregation and consistent region ordering for clearer comparisons.
* **Improvements**
  * Regional heatmap colors now compare providers against the best result in each region.
  * Availability values display with improved precision.
  * Rankings and summaries now distinguish scored providers from providers without score data.
* **Bug Fixes**
  * Improved handling and display of incomplete or unavailable provider metrics.
  * Provider score failures are now reflected in degraded metric status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->