### PR TITLE
refactor(rpc-performance): derive range/protocol state instead of syncing in effects

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,14 +5,6 @@ import coreWebVitals from 'eslint-config-next/core-web-vitals';
 const config = [
   { ignores: ['.next/**', 'out/**', 'build/**', 'next-env.d.ts'] },
   ...coreWebVitals,
-  {
-    rules: {
-      // eslint-plugin-react-hooks 6 (new in eslint-config-next 16) added this rule.
-      // Two pre-existing prop->state sync effects trip it; downgraded to a warning so
-      // the dependency upgrade stays separate from refactoring those effects.
-      'react-hooks/set-state-in-effect': 'warn',
-    },
-  },
 ];
 
 export default config;

--- a/src/components/RpcPerformance/RpcPerformancePage.tsx
+++ b/src/components/RpcPerformance/RpcPerformancePage.tsx
@@ -87,9 +87,18 @@ export default function RpcPerformancePage({ allChainsData, chains, timeRange = 
   const searchParams = useSearchParams();
   const [isTimeRangeLoading, setIsTimeRangeLoading] = useState(false);
 
-  const [activeProtocol, setActiveProtocol] = useState(() =>
-    resolveProtocol(chains, searchParams.get('protocol'))
-  );
+  const urlProtocol = searchParams.get('protocol');
+  const [activeProtocol, setActiveProtocol] = useState(() => resolveProtocol(chains, urlProtocol));
+  const [syncedUrlProtocol, setSyncedUrlProtocol] = useState(urlProtocol);
+
+  // Sync back when the router's URL changes (e.g. back/forward navigation).
+  // Adjusted during render rather than in an effect, and keyed on the param
+  // value instead of the searchParams object, so an unrelated `range` change no
+  // longer triggers a redundant reset to the same protocol.
+  if (syncedUrlProtocol !== urlProtocol) {
+    setSyncedUrlProtocol(urlProtocol);
+    setActiveProtocol(resolveProtocol(chains, urlProtocol));
+  }
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -97,10 +106,6 @@ export default function RpcPerformancePage({ allChainsData, chains, timeRange = 
     const range = url.searchParams.get('range') || timeRange;
     window.history.replaceState(null, '', `?${rangeQuery({ protocol, range })}`);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    setActiveProtocol(resolveProtocol(chains, searchParams.get('protocol')));
-  }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleProtocolChange(p: string) {
     setActiveProtocol(p);

--- a/src/components/RpcPerformance/TimeRangeSwitcher.tsx
+++ b/src/components/RpcPerformance/TimeRangeSwitcher.tsx
@@ -18,17 +18,20 @@ interface TimeRangeSwitcherProps {
 export default function TimeRangeSwitcher({ current, onLoadingChange }: TimeRangeSwitcherProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const [optimistic, setOptimistic] = useState<TimeRange>(current);
+  const [clicked, setClicked] = useState<TimeRange | null>(null);
 
-  // Sync back if server overrides (e.g. on back/forward navigation)
-  useEffect(() => { setOptimistic(current); }, [current]);
+  // Derived, not synced state: show the clicked range only while the navigation
+  // is in flight, then fall back to whatever the server resolved. This means
+  // back/forward navigation needs no sync — `current` is always the source of
+  // truth the moment the transition settles.
+  const optimistic = isPending && clicked ? clicked : current;
 
   useEffect(() => {
     onLoadingChange?.(isPending);
   }, [isPending]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleChange(value: TimeRange) {
-    setOptimistic(value); // instant visual switch
+    setClicked(value); // instant visual switch
     const cur = new URLSearchParams(window.location.search);
     const query = rangeQuery({ protocol: cur.get('protocol'), range: value });
     startTransition(() => {


### PR DESCRIPTION
Follow-up to #14. That PR parked `react-hooks/set-state-in-effect` at `warn` to keep the Next 16 upgrade free of component behavior changes. This PR fixes both sites and restores the rule to `error`.

Both findings predate Next 16 — `eslint-config-next@16` bundles eslint-plugin-react-hooks 6, which added the rule and surfaced them.

## `TimeRangeSwitcher.tsx` — fully derived

The optimistic range was stored in state and re-synced from the `current` prop in an effect. It's now derived:

```js
const optimistic = isPending && clicked ? clicked : current;
```

Show the clicked range only while the navigation is in flight, then fall back to `current`. Back/forward needs no sync at all — `current` is authoritative the moment the transition settles. This **removes** a state variable rather than adding one.

## `RpcPerformancePage.tsx` — adjusted during render

This one can't be fully derived. Chip clicks use `window.history.replaceState`, which deliberately bypasses the router so switching is instant — all chains' data is already client-side. Making `searchParams` the single source of truth would require `router.replace` and a server round-trip per chip click, since the page is `force-dynamic`. That's a UX regression, so `activeProtocol` stays state.

Instead it uses the [render-phase adjustment pattern](https://react.dev/learn/you-might-not-need-an-effect), keyed on the **protocol param value** rather than the `searchParams` object — so an unrelated `range` change no longer triggers a redundant reset to the same protocol.

## Verification

Driven in real Chrome and compared **refactored vs. original** across four scenarios. Output was identical:

| Step | Result |
|---|---|
| `load ?protocol=solana` | `{"chip":"Solana","range":"24h"}` |
| chip click (3rd) | `{"chip":"BNB Chain","range":"24h"}` |
| click `7d` | `{"chip":"BNB Chain","range":"7d"}` ← protocol preserved |
| `goBack` | `{"chip":"Ethereum","range":"24h"}` |
| `goForward` | `{"chip":"BNB Chain","range":"7d"}` |

No React hydration warnings, no page errors. `eslint .` exits 0; build passes.

## Pre-existing issue found, not addressed here

`useSearchParams()` returns empty during prerender inside the `loading.tsx` boundary, so a deep link like `?protocol=solana` server-renders with **Ethereum** active and only corrects after hydration — a brief wrong-chip flash. Verified identical on unmodified `main`, so it is not introduced by this PR or by #14. Worth a separate fix if we want deep links to render correctly on first paint.

## Review notes

Worth exercising in the preview env: deep-link a protocol, switch chips, toggle 24h/7d, then browser back/forward — confirming the active chip and range always track the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protocol selection now correctly synchronizes with URL parameters during navigation, including browser back/forward
  * Time range selection provides immediate visual feedback while navigation completes
  * Prevented unintended resets when unrelated query parameters change

* **Chores**
  * Removed custom ESLint rule configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->