### PR TITLE
chore: remove dead CSS, unused code, and stale config entries

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,10 +10,12 @@ const isPreview = process.env.VERCEL_ENV === 'preview';
 const cspDirectives = [
   "default-src 'self'",
   `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.segment.com https://www.googletagmanager.com https://www.google-analytics.com${isPreview ? ' https://vercel.live' : ''}`,
-  `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com${isPreview ? ' https://vercel.live' : ''}`,
-  `font-src 'self' https://fonts.gstatic.com data:${isPreview ? ' https://vercel.live/fonts' : ''}`,
+  // next/font self-hosts Space Mono, so no Google Fonts origins are needed.
+  `style-src 'self' 'unsafe-inline'${isPreview ? ' https://vercel.live' : ''}`,
+  `font-src 'self' data:${isPreview ? ' https://vercel.live/fonts' : ''}`,
   "img-src 'self' data: https:",
-  `frame-src https://chainstack.grafana.net${isPreview ? ' https://vercel.live' : ''}`,
+  // Nothing is iframed in production; Grafana opens via target="_blank" links.
+  `frame-src ${isPreview ? 'https://vercel.live' : "'none'"}`,
   `connect-src 'self' https://api.segment.io https://*.segment.io https://www.google-analytics.com${isPreview ? ' https://vercel.live wss://ws-us3.pusher.com https://*.pusher.com' : ''}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "Node performance tool",
+  "name": "performance-tool",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Node performance tool",
+      "name": "performance-tool",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "next": "16.2.12",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Node performance tool",
+  "name": "performance-tool",
   "version": "1.0.0",
   "private": true,
   "license": "Apache-2.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,139 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Typography tokens (Figma Design System 2.0, node 5812:2933) ──
+   Trimmed to the two styles this app uses; the full sheet lives in Figma. */
 :root {
-  /* bg */
-  --color-bg:                      #03070d;
-  --color-bg-elevated:             #1F2228;
-  --color-bg-elevated-contrast:    #002150;
-  --color-bg-overlay:              rgba(9,10,11,0.5);
-  --color-bg-scrim:                rgba(2,2,3,0.6);
-
-  /* text */
-  --color-text-primary:            #F6F9FD;
-  --color-text-secondary:          #8D95A5;
-  --color-text-tertiary:           #656E80;
-
-  /* border */
-  --color-border-static:           #2E3338;
-  --color-border-default:          #40474E;
-  --color-border-hover:            #5E666E;
-
-  /* blue */
-  --color-blue-brand:              #007BFF;
-  --color-blue-dark:               #4DAFFF;
-  --color-blue-darkest:            #80C3FF;
-  --color-blue-light:              #004C9E;
-
-  /* base */
-  --color-base-white:              #FFFFFF;
-  --color-base-black:              #1A1D23;
-
-  /* icon */
-  --color-icon-default:            #73808C;
-  --color-icon-hover:              #DEE6ED;
-
-  /* button */
-  --color-button-primary:          #007BFF;
-  --color-button-primary-hover:    #005EE0;
-  --color-button-secondary:        #03264F;
-  --color-button-secondary-hover:  #043876;
-  --color-button-secondary-content:#007BFF;
-  --color-button-disabled:         #22252B;
-  --color-button-disabled-content: #54575F;
-
-  /* status — contrast (text/icon on dark bg) */
-  --color-status-success:          #25B15F;
-  --color-status-warning:          #FFDD33;
-  --color-status-error:            #FF294C;
-  --color-status-info:             #25A4FF;
-
-  /* status — surface (background of badge) */
-  --color-status-success-surface:  #124A24;
-  --color-status-warning-surface:  #563906;
-  --color-status-error-surface:    #591721;
-  --color-status-info-surface:     #0B3F65;
-
-  /* tag */
-  --color-tag-blue-surface:        #024156;
-  --color-tag-blue-content:        #8AD5EF;
-  --color-tag-purple-surface:      #5A116B;
-  --color-tag-purple-content:      #E9A8FA;
-  --color-tag-orange-surface:      #4C3203;
-  --color-tag-orange-content:      #F9C56C;
-  --color-tag-magenta-surface:     #570F3A;
-  --color-tag-magenta-content:     #F88FAA;
-}
-
-/* ── Typography tokens (Figma Design System 2.0, node 5812:2933) ── */
-:root {
-  /* font-size */
-  --font-size-hero:      56px;
-  --font-size-h1:        40px;
-  --font-size-h2:        32px;
-  --font-size-h3:        28px;
-  --font-size-h4:        24px;
-  --font-size-subtitle-l: 18px;
-  --font-size-subtitle-m: 16px;
+  --font-size-h2:         32px;
+  --lh-h2:                38px;
   --font-size-subtitle-s: 14px;
-  --font-size-body-l:    18px;
-  --font-size-body-m:    16px;
-  --font-size-body-s:    14px;
-  --font-size-body-xs:   12px;
-  --font-size-caption-m: 16px;
-  --font-size-caption-s: 14px;
-  --font-size-caption-xs:12px;
-  --font-size-btn-l:     15px;
-  --font-size-btn-m:     13px;
-
-  /* line-height */
-  --lh-hero:      68px;
-  --lh-h1:        48px;
-  --lh-h2:        38px;
-  --lh-h3:        34px;
-  --lh-h4:        28px;
-  --lh-subtitle-l: 24px;
-  --lh-subtitle-m: 20px;
-  --lh-subtitle-s: 18px;
-  --lh-body-l:    24px;
-  --lh-body-m:    20px;
-  --lh-body-s:    18px;
-  --lh-body-xs:   16px;
-  --lh-caption-m: 20px;
-  --lh-caption-s: 18px;
-  --lh-caption-xs:16px;
-  --lh-btn-l:     20px;
-  --lh-btn-m:     18px;
-
-  /* letter-spacing */
-  --ls-heading:   -2%;   /* applied via calc in JS — use JS constants */
-  --ls-subtitle:  -1%;
-  --ls-body:      0;
-  --ls-caption:   -1%;
-  --ls-btn:       1%;
+  --lh-subtitle-s:        18px;
 }
 
-/* Utility classes */
-.type-hero      { font-size: var(--font-size-hero);      line-height: var(--lh-hero);       font-weight: 500; letter-spacing: -1.12px; }
-.type-h1        { font-size: var(--font-size-h1);        line-height: var(--lh-h1);         font-weight: 500; letter-spacing: -0.8px;  }
 .type-h2        { font-size: var(--font-size-h2);        line-height: var(--lh-h2);         font-weight: 500; letter-spacing: -0.64px; }
-.type-h3        { font-size: var(--font-size-h3);        line-height: var(--lh-h3);         font-weight: 500; letter-spacing: -0.56px; }
-.type-h4        { font-size: var(--font-size-h4);        line-height: var(--lh-h4);         font-weight: 500; letter-spacing: -0.48px; }
-.type-subtitle-l{ font-size: var(--font-size-subtitle-l);line-height: var(--lh-subtitle-l); font-weight: 500; letter-spacing: -0.18px; }
-.type-subtitle-m{ font-size: var(--font-size-subtitle-m);line-height: var(--lh-subtitle-m); font-weight: 500; letter-spacing: -0.16px; }
 .type-subtitle-s{ font-size: var(--font-size-subtitle-s);line-height: var(--lh-subtitle-s); font-weight: 500; letter-spacing: -0.14px; }
-.type-body-l    { font-size: var(--font-size-body-l);    line-height: var(--lh-body-l);     font-weight: 400; letter-spacing: 0;       }
-.type-body-m    { font-size: var(--font-size-body-m);    line-height: var(--lh-body-m);     font-weight: 400; letter-spacing: 0;       }
-.type-body-s    { font-size: var(--font-size-body-s);    line-height: var(--lh-body-s);     font-weight: 400; letter-spacing: 0;       }
-.type-body-xs   { font-size: var(--font-size-body-xs);   line-height: var(--lh-body-xs);    font-weight: 400; letter-spacing: -0.12px; }
-.type-caption-m { font-size: var(--font-size-caption-m); line-height: var(--lh-caption-m);  font-weight: 450; letter-spacing: -0.16px; }
-.type-caption-s { font-size: var(--font-size-caption-s); line-height: var(--lh-caption-s);  font-weight: 450; letter-spacing: -0.14px; }
-.type-caption-xs{ font-size: var(--font-size-caption-xs);line-height: var(--lh-caption-xs); font-weight: 450; letter-spacing: -0.12px; }
-.type-btn-l     { font-size: var(--font-size-btn-l);     line-height: var(--lh-btn-l);      font-weight: 500; letter-spacing: 0.15px;  }
-.type-btn-m     { font-size: var(--font-size-btn-m);     line-height: var(--lh-btn-m);      font-weight: 500; letter-spacing: 0.13px;  }
 
 html, body {
-  font-family: 'Suisse Int\'l', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 /* Space Mono for all monospace elements */
@@ -142,48 +23,6 @@ html, body {
   font-family: var(--font-space-mono), 'Courier New', monospace !important;
   letter-spacing: -0.3px;
 }
-
-.toc-card {
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-static);
-  border-radius: 12px;
-  padding: 16px;
-  transition: border-color 0.15s ease;
-  display: block;
-  text-decoration: none;
-}
-.toc-card:hover {
-  border-color: var(--color-border-default);
-}
-
-.fix-input-bg { background-color: transparent !important; }
-
-.fix-cta-button {
-  padding: 12px !important;
-  font-size: 14px !important;
-  line-height: 24px !important;
-}
-
-.text-accent { color: var(--color-blue-brand); }
-
-.custom-bento-card {
-  border-radius: 16px;
-  border: 1px solid rgba(255,255,255,0.16);
-  background: radial-gradient(
-      102.78% 100.22% at 21.68% 25.66%,
-      rgba(255,255,255,0.05) 0%, rgba(0,0,0,0) 38.9%, rgba(255,255,255,0.05) 85.47%
-    ), rgba(0,4,26,0.6);
-  backdrop-filter: blur(10px);
-}
-
-.custom-bento-card:hover {
-  background: radial-gradient(
-      21.68% 25.66% at 102.78% 100.22%,
-      rgba(255,255,255,0.05) 0%, rgba(0,0,0,0) 38.9%, rgba(255,255,255,0.05) 85.47%
-    ), hsla(231,100%,7.5%,0.6);
-  transition: all 0.5s ease;
-}
-
 
 /* ── Infra background ── */
 .infra-bg {
@@ -224,11 +63,4 @@ html, body {
 /* ── LiveDot ── */
 @keyframes ping {
   75%, 100% { transform: scale(2); opacity: 0; }
-}
-
-@keyframes tooltipFade {
-  0%   { opacity: 0; }
-  12%  { opacity: 1; }
-  75%  { opacity: 1; }
-  100% { opacity: 0; }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -39,7 +39,6 @@ const Header = () => {
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
         className="inline-flex items-center justify-center bg-[#007BFF] hover:bg-[#005EE0] text-white border-none rounded-lg px-6 py-2.5 text-[15px] font-medium leading-5 tracking-[0.15px] no-underline cursor-pointer whitespace-nowrap transition-colors"
-        style={{ fontFamily: "\"Suisse Int'l\", sans-serif" }}
       >
         Start for free
       </a>

--- a/src/components/RpcPerformance/brandColors.ts
+++ b/src/components/RpcPerformance/brandColors.ts
@@ -1,4 +1,4 @@
-export interface Rgb {
+interface Rgb {
   r: number;
   g: number;
   b: number;
@@ -21,10 +21,6 @@ export const CHAIN_BRAND: Record<string, ChainBrand> = {
   Robinhood:   { rgb: { r: 204, g: 255, b: 0   }, logo: 'robinhood'   },
   Solana:      { rgb: { r: 153, g: 69,  b: 255 }, logo: 'solana'      },
 };
-
-export function brandRgb(chain: string): Rgb | null {
-  return CHAIN_BRAND[chain]?.rgb ?? null;
-}
 
 export function chainLogo(chain: string): string | null {
   return CHAIN_BRAND[chain]?.logo ?? null;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,6 @@ const primaryBlue = {
 
 const config = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
 


### PR DESCRIPTION
## What

Dead-code cleanup from a full repo review — net **−171 lines**, no behavior change except one deliberate color fix (below).

- **`globals.css` trimmed ~60%.** Removed selectors with no consumer anywhere in `src/`: `.toc-card`, `.fix-input-bg`, `.fix-cta-button`, `.custom-bento-card`, `@keyframes tooltipFade`, 12 of the 14 `type-*` utilities (only `type-h2` and `type-subtitle-s` are used), and the unconsumed `--color-*` / `--ls-*` token blocks. Plain CSS isn't Tailwind-purged, so all of this shipped in the bundle on every load.
- **`text-accent` collision resolved.** `globals.css` defined `.text-accent { color: #007BFF }` after `@tailwind utilities`, shadowing the Tailwind `accent: '#4DAFFF'` utility. The globals rule is gone, so the **"Grafana ↗" link changes from #007BFF to #4DAFFF** — the color the Tailwind config (and the table accent default) always intended. This is the one visible change to check in preview.
- **"Suisse Int'l" references dropped.** Named in the body font stack and a `Header.tsx` inline style, but never loaded (no `@font-face`, no `next/font`) — every visitor already got the system-sans fallback, so this changes nothing visually; the CSS just stops claiming a font it doesn't have.
- **CSP tightened** (`next.config.js`): removed `fonts.googleapis.com` / `fonts.gstatic.com` (`next/font` self-hosts Space Mono, those origins are never contacted) and `frame-src https://chainstack.grafana.net` (nothing is iframed; Grafana opens via `target="_blank"`, which `frame-src` doesn't govern). Production `frame-src` is now `'none'`; preview keeps `https://vercel.live` for the toolbar. Segment/GA origins untouched.
- **Small stuff:** removed never-imported `brandRgb()` and the `Rgb` export from `brandColors.ts`, dropped the nonexistent `./src/pages/**` Tailwind content glob, renamed the package from `"Node performance tool"` to the npm-valid `performance-tool`.

## What to verify in preview

- "Grafana ↗" link color is now the lighter blue (#4DAFFF) — intended.
- Typography unchanged: page heading (`type-h2`), provider names (`type-subtitle-s`), backgrounds (infra gradient, dot grid, grain), LiveDot ping.
- Vercel toolbar still loads on the preview deployment (frame-src change).

## Checks

- `npm run lint` ✅  `npm run build` ✅  `npm audit` 0 vulnerabilities
- Smoke-tested `next start`: page renders, built CSS chunk contains all kept selectors and none of the removed ones, CSP header matches intent.

Follow-up (separate PR, as discussed): evaluate dropping `@lemonsqueezy/wedges`, which pins React 18 and Tailwind 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)