### PR TITLE
fix: keep ranking tooltip centered during its entrance animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,14 +42,17 @@
       opacity: 0.4;
     }
   }
+  /* No translateX here: Tailwind 4's `-translate-x-1/2` emits the standalone
+     `translate` property, which composes with `transform` instead of being
+     overridden by it. Re-centering here would double the shift mid-animation. */
   @keyframes tooltipIn {
     from {
       opacity: 0;
-      transform: translateX(-50%) translateY(4px);
+      transform: translateY(4px);
     }
     to {
       opacity: 1;
-      transform: translateX(-50%) translateY(0);
+      transform: translateY(0);
     }
   }
 }


### PR DESCRIPTION
Hovering **How ranking works** made the tooltip appear offset to the left, then blink and shift right as the entrance animation finished.

## Cause

Tailwind 4 compiles `-translate-x-1/2` to the standalone `translate` property:

```css
.-translate-x\/2 { --tw-translate-x: calc(calc(1 / 2 * 100%) * -1); translate: var(--tw-translate-x) var(--tw-translate-y) }
```

`translate` and `transform` both apply, in that order. The `tooltipIn` keyframe carried its own `translateX(-50%)` on `transform`, so for the 150 ms the animation ran the tooltip was shifted a full width left. The animation sets no `fill-mode`, so once it ended `transform` reverted to `none` and only the utility's `-50%` remained — the snap back to centre.

Under Tailwind 3 the utility compiled to a `transform:` declaration, which the animation overrode outright; the keyframe's `translateX(-50%)` was what kept it centred. The keyframe is unchanged since then — moving translate utilities to the `translate` property turned that duplicate into an additive one.

## Fix

Drop the X translate from the keyframe and let the utility own the centring. `translateY(0)` → `none` at animation end is visually identical, so nothing shifts.

Built CSS after the change:

```css
@keyframes tooltipIn{0%{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}
```

## Checks

- `npm run lint` — no issues
- `npm run build` — passes

`animate-tooltipIn` has no other users. The "Copied" tooltip uses the same `-translate-x-1/2` but is not animated, so it was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip animations so horizontal centering is preserved while the tooltip moves vertically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->