### PR TITLE
docs: correct stale README and CLAUDE.md claims, patch advisories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Each one is deliberate, looks like something to tidy up, and breaks if you do.
 
 **The three `package.json` overrides are load-bearing.** `postcss` because Next pins `8.4.31` internally, `minimatch` as the only route to a patched `brace-expansion`, `sharp` because Next's optional range has an open advisory. Removing any reintroduces a Dependabot alert.
 
-**ESLint stays on 9.x.** ESLint 10 breaks two ways — `eslint-plugin-react` supports nothing above 9.7, and `eslint-config-next`'s parser is vendored inside `next`. Neither is fixable with an override.
+**ESLint stays on 9.x.** `eslint-plugin-react` peers at `^9.7` and nothing higher, and no override fixes a peer range.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 RPC provider performance comparison, as a single-page Next.js app. Chainstack Compare frontend.
 
-Shows P50/P95/P99 latency, availability, and per-region breakdowns for RPC providers across Ethereum, Solana, BNB Chain, Arbitrum, Base, Hyperliquid, and Robinhood, measured from four regions.
+Shows P50/P95/P99 latency, availability, and per-region breakdowns for RPC providers across Ethereum, Solana, BNB Chain, Arbitrum, Base, Hyperliquid, and Robinhood, measured from three regions per chain (four across the probe fleet).
 
 This app only renders. The probes and dashboards that produce the data live in [compare-dashboard-functions](https://github.com/chainstacklabs/compare-dashboard-functions); this app queries their Grafana at request time.
 
 ## Setup
 
-Needs Node.js 20.9 or later.
+Needs Node.js 22.
 
 ```bash
 npm install
@@ -16,6 +16,8 @@ cp .env.sample .env.local
 ```
 
 Set `GRAFANA_API_TOKEN` in `.env.local` — a Grafana service account token with the Viewer role. Without it the page renders but every metric shows as unavailable.
+
+`NEXT_PUBLIC_CLIENT_DOMAIN` is optional — it only fills in the `og:image` and `og:url` metadata.
 
 To run against your own Grafana, change `GRAFANA_URL` and `PROM_DS_UID` in `src/lib/grafana.ts` and the `CHAINS` list in `src/lib/queries.ts`.
 
@@ -42,7 +44,7 @@ Unrecognized values fall back to the default, so links are safe to share.
 ```
 src/app/          # single route, layout, loading fallback
 src/components/   # RpcPerformance/ holds the table, chips, range switcher
-src/lib/          # PromQL, Grafana client, scoring
+src/lib/          # PromQL, Grafana client, scoring, URL params
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "postcss": "^8.5.25",
         "tailwindcss": "^4.3.3",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4650,9 +4653,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -5176,9 +5179,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## README

- Stated Node.js 20.9 or later. `.nvmrc` and `package.json` `engines` have required Node 22 since the ESM config change.
- Described measurements as coming from four regions. The probe fleet spans four (`fra1`, `sfo1`, `sin1`, `hnd1`), but each chain is probed from three — Ethereum, BNB Chain, Robinhood and Solana from EU, Singapore and US West; Arbitrum, Base and Hyperliquid from EU, Japan and US West. No chain shows four region columns.
- Documents `NEXT_PUBLIC_CLIENT_DOMAIN`, which `.env.sample` carries and `src/app/layout.tsx` reads for og metadata, but Setup never mentioned.
- `src/lib/` layout line now names URL params alongside PromQL, the Grafana client and scoring.

## CLAUDE.md

The ESLint note gave two reasons the project cannot move to ESLint 10. Only one is still true: `eslint-plugin-react@7.37.5` peers at `^9.7` and nothing higher. `eslint-config-next@16.2.12` declares `typescript-eslint: ^8.46.0` as an ordinary dependency, so the vendored-parser reason no longer applies.

## Dependencies

`npm audit fix` clears two high-severity advisories that the existing `overrides` do not cover:

- `nanoid` 3.3.16 → 3.3.18, reached through `postcss`, so production
- `js-yaml` 4.3.0 → 4.3.1, dev only

It also records `engines.node` in the lockfile, which `package.json` has declared since the Node 22 pin but the lockfile never picked up. `npm audit` now reports 0 vulnerabilities.

## Checks

`npm run lint` reports no issues and `npm run build` compiles with TypeScript clean. Docs and lockfile only — no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)