### PR TITLE
chore: remove dead code, fix Segment CSP, document analysis tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,15 @@ Single-page Next.js app showing RPC provider performance. One route `/`, rendere
 
 `npm run lint` and `npm run build`. There is no test suite, so these are the only automated checks — run both before calling work done. For interactive changes, also load the page and click through it; the build passes on plenty that is broken at runtime.
 
-Needs `GRAFANA_API_TOKEN` in `.env.local` or every metric reads as unavailable.
+Needs `GRAFANA_API_TOKEN` in `.env.local` or every metric reads as unavailable — a local run without it exercises the render path, not the data path, so clicking through proves less than it appears to.
+
+Deeper sweeps are a one-off, not a per-PR gate, and deliberately not `devDependencies` — they add ~157 packages to a 433-package tree for something run a few times a year, against a repo that keeps `npm audit` at zero on purpose. Reach for them with `npx` when doing dead-code or dependency work:
+
+- `npx knip` — unused files, exports and dependencies. The one that finds what grep misses, because it tells a function apart from a same-named property.
+- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` — unused locals and parameters, which the committed `tsconfig.json` does not enable.
+- `npx eslint . --max-warnings 0` — fails on warnings that `npm run lint` prints but tolerates.
+- `npx madge --circular --extensions ts,tsx --ts-config tsconfig.json src/` — import cycles. `--ts-config` is required: without it the `@/` alias goes unresolved and every aliased module is falsely reported as an orphan.
+- `npx depcheck` — reports `tailwindcss`, `@tailwindcss/postcss` and the `@types/*` packages as unused. It cannot see CSS `@import`, a `.mjs` config, or ambient types, so treat those as noise; `knip` is right where the two disagree.
 
 ## Constraints
 
@@ -25,6 +33,8 @@ Each one is deliberate, looks like something to tidy up, and breaks if you do.
 **The three `package.json` overrides are load-bearing.** `postcss` because Next pins `8.4.31` internally, `minimatch` as the only route to a patched `brace-expansion`, `sharp` because Next's optional range has an open advisory. Removing any reintroduces a Dependabot alert.
 
 **ESLint stays on 9.x.** `eslint-plugin-react` peers at `^9.7` and nothing higher, and no override fixes a peer range.
+
+**Next rewrites `tsconfig.json` on every build.** `allowJs` and `resolveJsonModule` look unused — no `.js` file matches `include`, nothing imports JSON — but removing either lasts only until the next `npm run build`, which re-adds it and reformats the file.
 
 ## Conventions
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from 'next';
+import { CHAINS } from './src/lib/queries';
+
+// /dashboard lands on Ethereum's public compare dashboard. The token comes from
+// CHAINS so it stays in step with the app's own "open in Grafana" links rather
+// than being a second copy that can drift. Fail the build if it is missing — a
+// broken redirect target is worse than a loud error.
+const ethereumToken = CHAINS.find((c) => c.promName === 'Ethereum')?.publicToken;
+if (!ethereumToken) throw new Error('No Ethereum entry in CHAINS to build the /dashboard redirect from');
 
 const GRAFANA_DASHBOARD_URL =
-  'https://chainstack.grafana.net/public-dashboards/65c0fcb02f994faf845d4ec095771bd0?orgId=1';
+  `https://chainstack.grafana.net/public-dashboards/${ethereumToken}?orgId=1`;
 
 // Allow the Vercel toolbar (comments/live feedback) on preview deployments only,
 // so production stays locked down. The toolbar loads from vercel.live and uses

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,7 +27,10 @@ const cspDirectives = [
   "img-src 'self' data: https:",
   // Nothing is iframed in production; Grafana opens via target="_blank" links.
   `frame-src ${isPreview ? 'https://vercel.live' : "'none'"}`,
-  `connect-src 'self' https://api.segment.io https://*.segment.io${isPreview ? ' https://vercel.live wss://ws-us3.pusher.com https://*.pusher.com' : ''}`,
+  // cdn.segment.com appears here as well as in script-src: analytics.js fetches
+  // its destination settings from cdn.segment.com over fetch(), which connect-src
+  // governs. Without it the bundle loads but cannot initialise.
+  `connect-src 'self' https://cdn.segment.com https://api.segment.io https://*.segment.io${isPreview ? ' https://vercel.live wss://ws-us3.pusher.com https://*.pusher.com' : ''}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,14 +18,16 @@ const isPreview = process.env.VERCEL_ENV === 'preview';
 
 const cspDirectives = [
   "default-src 'self'",
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.segment.com https://www.googletagmanager.com https://www.google-analytics.com${isPreview ? ' https://vercel.live' : ''}`,
+  // cdn.segment.com serves the analytics.js bundle loaded in layout.tsx. Adding a
+  // browser-side (device-mode) Segment destination means adding its origin here.
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.segment.com${isPreview ? ' https://vercel.live' : ''}`,
   // next/font self-hosts Space Mono, so no Google Fonts origins are needed.
   `style-src 'self' 'unsafe-inline'${isPreview ? ' https://vercel.live' : ''}`,
   `font-src 'self' data:${isPreview ? ' https://vercel.live/fonts' : ''}`,
   "img-src 'self' data: https:",
   // Nothing is iframed in production; Grafana opens via target="_blank" links.
   `frame-src ${isPreview ? 'https://vercel.live' : "'none'"}`,
-  `connect-src 'self' https://api.segment.io https://*.segment.io https://www.google-analytics.com${isPreview ? ' https://vercel.live wss://ws-us3.pusher.com https://*.pusher.com' : ''}`,
+  `connect-src 'self' https://api.segment.io https://*.segment.io${isPreview ? ' https://vercel.live wss://ws-us3.pusher.com https://*.pusher.com' : ''}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@types/react-dom": "^19.2.4",
         "eslint": "^9.39.5",
         "eslint-config-next": "16.2.12",
-        "postcss": "^8.5.25",
         "tailwindcss": "^4.3.3",
         "typescript": "^5"
       },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/react-dom": "^19.2.4",
     "eslint": "^9.39.5",
     "eslint-config-next": "16.2.12",
-    "postcss": "^8.5.25",
     "tailwindcss": "^4.3.3",
     "typescript": "^5"
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
   --color-fg-faint: #606772;
   --color-fg-ghost: #4a5260;
 
-  /* Availability tier colors (see metrics.js availTier()) */
+  /* Availability tier colors (see availTier() in RpcPerformance/metrics.ts) */
   --color-tier-healthy: #25b15f;
   --color-tier-acceptable: #6fc784;
   --color-tier-degraded: #ffdd33;

--- a/src/components/RpcPerformance/RpcPerformancePage.tsx
+++ b/src/components/RpcPerformance/RpcPerformancePage.tsx
@@ -8,7 +8,7 @@ import ProviderMetricsTable from './ProviderMetricsTable';
 import TimeRangeSwitcher from './TimeRangeSwitcher';
 import TableSkeleton from './TableSkeleton';
 import { enrichProviders, computeScores, sortByScore, generateSummary } from './metrics';
-import { brandHex } from './brandColors';
+import { brandColor } from './brandColors';
 import { resolveProtocol, rangeQuery } from '@/lib/url-params';
 import type { Chain, ChainData, TimeRange } from '@/lib/types';
 
@@ -139,7 +139,7 @@ export default function RpcPerformancePage({ allChainsData, chains, timeRange = 
     [chainData, sortedProviders]
   );
 
-  const accentColor = brandHex(activeProtocol);
+  const accentColor = brandColor(activeProtocol);
   const grafanaFrom = timeRange === '7d' ? 'now-7d' : 'now-24h';
   const dashboardUrl = chainData
     ? `https://chainstack.grafana.net/public-dashboards/${chainData.chain.publicToken}?orgId=1&theme=dark&from=${grafanaFrom}&to=now`

--- a/src/components/RpcPerformance/brandColors.ts
+++ b/src/components/RpcPerformance/brandColors.ts
@@ -32,7 +32,8 @@ export function brandRgba(chain: string, alpha: number): string | null {
   return `rgba(${c.r},${c.g},${c.b},${alpha})`;
 }
 
-export function brandHex(chain: string): string {
+/** CSS color for a chain's accent — `rgb()` when known, the accent hex otherwise. */
+export function brandColor(chain: string): string {
   const c = CHAIN_BRAND[chain]?.rgb;
   if (!c) return '#4DAFFF';
   return `rgb(${c.r},${c.g},${c.b})`;

--- a/src/components/RpcPerformance/brandColors.ts
+++ b/src/components/RpcPerformance/brandColors.ts
@@ -12,7 +12,7 @@ interface ChainBrand {
 
 // Single source of per-chain display metadata, keyed by promName. Adding a
 // chain means one entry here (plus the data entry in lib/queries.ts).
-export const CHAIN_BRAND: Record<string, ChainBrand> = {
+const CHAIN_BRAND: Record<string, ChainBrand> = {
   Ethereum:    { rgb: { r: 98,  g: 126, b: 234 }, logo: 'ethereum'    },
   Arbitrum:    { rgb: { r: 40,  g: 160, b: 240 }, logo: 'arbitrum'    },
   Base:        { rgb: { r: 0,   g: 82,  b: 255 }, logo: 'base'        },

--- a/src/components/RpcPerformance/metrics.ts
+++ b/src/components/RpcPerformance/metrics.ts
@@ -38,7 +38,7 @@ export function enrichProviders(providers: Provider[]): EnrichedProvider[] {
  *  degraded    [95.0, 99.0)
  *  unhealthy   < 95.0%
  */
-export function availTier(pct: number | null): AvailTier {
+function availTier(pct: number | null): AvailTier {
   if (!isNum(pct)) return 'unknown';
   if (pct >= 99.9) return 'healthy';
   if (pct >= 99.0) return 'acceptable';

--- a/src/lib/chain-data.ts
+++ b/src/lib/chain-data.ts
@@ -117,7 +117,6 @@ export const fetchChainData = cache(async (chain: Chain, timeRange: TimeRange = 
       p95: avgOfMap(p95Map.get(name)),
       p99: avgOfMap(p99Map.get(name)),
       regions: Object.fromEntries(p95Map.get(name) ?? []) as Record<string, number>,
-      regionSuccess: Object.fromEntries(successMap.get(name) ?? []) as Record<string, number>,
       trend: trendMap.get(name) ?? [],
       success: avgOfMap(successMap.get(name)),
       // Joined on the raw `provider` label, which is the same identity Grafana's

--- a/src/lib/chain-data.ts
+++ b/src/lib/chain-data.ts
@@ -139,7 +139,6 @@ export const fetchChainData = cache(async (chain: Chain, timeRange: TimeRange = 
     chain,
     providers,
     regions: [...regions].sort(),
-    leader: providers[0] ?? null,
     error: providers.length === 0 && hadError,
     // Some queries failed but we still have providers — data is incomplete and
     // the ranking may be affected. Surfaced in the UI rather than hidden.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,8 +14,6 @@ export interface Provider {
   p99: number | null;
   /** region code → p95 latency in seconds */
   regions: Record<string, number>;
-  /** region code → success rate 0–1 */
-  regionSuccess: Record<string, number>;
   /** p95 trend points in seconds */
   trend: number[];
   /** mean success rate 0–1 across regions, or null when unknown (display only) */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,7 +31,6 @@ export interface ChainData {
   chain: Chain;
   providers: Provider[];
   regions: string[];
-  leader: Provider | null;
   /** true when there are no providers AND at least one query failed */
   error: boolean;
   /** true when providers exist but some query failed (data incomplete) */


### PR DESCRIPTION
Eleven commits, one per finding. Each was re-verified before and after the change.

## The one that matters for review

**`3cd1f04` — Segment analytics has been broken in production.** `analytics.js` loads its bundle from `cdn.segment.com`, then fetches the project's destination settings from the same origin. The bundle fetch is governed by `script-src`, which allowed it; the settings fetch goes through `connect-src`, which did not. So the script loaded and never initialised — one CSP violation, four console errors ending in `Failed to load Analytics.js`, a dead fallback to `analytics.classic.js`, and no page views recorded.

Confirmed pre-existing by running the same check against `main`: identical violation, identical errors. With `cdn.segment.com` added to `connect-src`, the page loads with zero CSP violations and zero console errors, and Segment makes three requests — bundle, settings, one page call.

## Dead code

| Commit | Change |
| --- | --- |
| `1839ec4` | `ChainData.leader` — set to `providers[0]` by p95 order, never read. The table's #1 comes from `sortByScore`, so a consumer wiring it up would have contradicted the displayed leader. |
| `515bc53` | `Provider.regionSuccess` — written for every provider, never read. Only the cross-region mean is displayed; the query is unchanged. |
| `ab94fd4` | `CHAIN_BRAND` made module-private. |
| `9fd481c` | `availTier` made module-private — the only external references are to the same-named property on `ScoredProvider`. |

## Cleanups

- `a3bfd7d` — `brandHex` → `brandColor`. It returns `rgb()` for every known chain and only falls back to a hex literal.
- `e2663e9` — the `/dashboard` redirect took the Ethereum dashboard token from a second hardcoded copy; it now reads `CHAINS` and fails the build if that entry disappears. Verified against a production server: still 308 to the same URL.
- `b9ed7c1` — `googletagmanager.com` and `google-analytics.com` removed from the CSP. Nothing loads them: the only third-party snippet is Segment, and that write key's sole browser-side destination is Segment.io. A real browser makes zero requests to either origin.
- `75dcdd4` — `postcss` dropped as a direct devDependency. Nothing imports it; `overrides.postcss` is what forces the patched version onto next's pinned `8.4.31`, and it does that either way. No resolved version changes and the override is untouched.
- `c45be33` — tier-color comment pointed at `metrics.ts` rather than a `metrics.js` that does not exist.

## Docs

`b75c8bb` records the deeper sweeps worth running for dead-code work, why they are not `devDependencies` (~157 packages added to a 433-package tree for something run a few times a year), and the trap in each — `madge` needs `--ts-config` or every `@/`-aliased module is falsely reported as an orphan, and `depcheck` cannot see CSS `@import`, a `.mjs` config, or ambient types.

It also records that Next re-adds `allowJs` and `resolveJsonModule` to `tsconfig.json` on every build. Both look unused — no `.js` file matches `include`, nothing imports JSON — but removing either does not survive the next build, so two candidate cleanups were dropped rather than committed.

## Verification

`npm run lint`, `npm run build`, `npx knip`, `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`, `npx eslint . --max-warnings 0`, `npx madge --circular`, and `npm audit` are all clean. A headless browser run against a production build shows no CSP violations, no console errors and no page errors, with protocol chips and the range switcher updating the URL correctly.

**Not covered locally:** without a Grafana token the table renders "Data unavailable", so scoring, sorting and the region columns were never exercised at runtime. Worth a look in the preview deployment, along with the browser console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved dashboard access by using the configured Ethereum Grafana credentials and validating setup during build configuration.
  - Updated content-security permissions to support Segment integrations while removing unused Google tracking origins.
  - Refined RPC performance branding and availability presentation for more consistent visual results.
- **Documentation**
  - Expanded development checks guidance, including required credentials, local-run limitations, and optional quality checks.
  - Documented build-related configuration constraints for Next.js.
- **Maintenance**
  - Simplified internal chain and provider data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->