### PR TITLE
fix: align frontend with updated dashboard ranking methodology

### DIFF
--- a/src/components/RpcPerformance/RpcPerformancePage.tsx
+++ b/src/components/RpcPerformance/RpcPerformancePage.tsx
@@ -34,6 +34,12 @@ function HowWeRank() {
           <div className="text-fg-muted text-[13px] leading-[18px] font-mono">
             Score = 1 / ((1/ResponseTime) × (SuccessRate³))
           </div>
+          {/* Mirrors the methodology text on the Grafana compare dashboards —
+              keep the two in sync when the panel description changes. */}
+          <div className="text-fg-dim text-xs leading-4 mt-1.5">
+            Per-method p95 latencies are combined as a harmonic mean, so no single
+            slow method dominates the score. All methods are weighted equally.
+          </div>
         </div>
       )}
     </div>

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -13,8 +13,14 @@ export const CHAINS: Chain[] = [
   { name: 'Robinhood',   promName: 'Robinhood',   publicToken: '5e422a0d05c74da493846cace52d2aa3' },
 ];
 
+// api_method="eth_subscribe" is excluded from latency displays: it measures
+// block arrival over a WebSocket subscription, which is bound by chain block
+// cadence and near-identical for every provider, so pooling it into the
+// per-provider average drowns the methods that actually differ. It still
+// counts toward availability (providerSuccessQuery below) and toward the
+// Grafana ranking score, both of which fold in its failures on purpose.
 const baseSelector = (chain: string): string =>
-  `response_latency_seconds{metric_type="response_time",blockchain="${chain}",response_status="success",provider!~"TEST_.*"}`;
+  `response_latency_seconds{metric_type="response_time",blockchain="${chain}",response_status="success",provider!~"TEST_.*",api_method!="eth_subscribe"}`;
 
 // Inner subquery window/resolution per time range. The coarser 5m step for 7d
 // keeps the sample count manageable (~2016 pts/series vs ~10k at 1m).


### PR DESCRIPTION
## What

Two follow-ups to the recent changes in [compare-dashboard-functions](https://github.com/chainstacklabs/compare-dashboard-functions) (measurement serialisation and the harmonic-mean score combination):

1. **Ranking tooltip** — the dashboards' "How we rank providers" text now states that per-method p95 latencies are combined as a harmonic mean with all methods weighted equally. The tooltip mirrors that text, so it gets the same clarification.

2. **Displayed latency aggregates** — `api_method="eth_subscribe"` is now excluded from the latency selector feeding P50/P95/P99, the regional heatmap, and the sparklines. The block-arrival probe measures chain block cadence, which is near-identical for every provider; once the serialisation fix lands and HTTP-method latencies drop, that constant would dominate the pooled average and erase the differences the table exists to show. Availability and the Grafana ranking score still count it — subscribe failures are real reliability signal, and the score formula stays in Grafana untouched.

## Verification

- `npm run lint` and `npm run build` pass on both commits.
- The selector change is a label-matcher addition to the existing PromQL; there is no `GRAFANA_API_TOKEN` in this environment, so the data path should be spot-checked on the Vercel preview (table should show latencies without the ~block-time floor on EVM chains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added methodology details to ranking tooltips, explaining how per-method p95 latency is calculated.
  * Updated provider latency displays to exclude subscription metrics for clearer request-latency comparisons.
  * Subscription metrics continue to contribute to availability calculations and overall ranking inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->